### PR TITLE
Fix Haiku support in HelpersFilesystemPaths.c

### DIFF
--- a/nuitka/build/static_src/HelpersFilesystemPaths.c
+++ b/nuitka/build/static_src/HelpersFilesystemPaths.c
@@ -182,7 +182,7 @@ int64_t getFileSize(FILE_HANDLE file_handle) {
 #if defined(__APPLE__)
 #include <copyfile.h>
 #else
-#if defined(__MSYS__)
+#if defined(__MSYS__) || defined(__HAIKU__)
 static bool sendfile(int output_file, int input_file, off_t *bytesCopied, size_t count) {
     char buffer[32768];
 


### PR DESCRIPTION
changed #if defined(__MSYS__) to #if defined(__MSYS__) || defined(__HAIKU__) for sendfile.

Thank your for contributing to Nuitka!

!! Please check that you select the **develop branch** (details see below link) !!

Before submitting a PR, please review the guidelines:
[Contributing Guidelines](https://github.com/Nuitka/Nuitka/blob/develop/CONTRIBUTING.md)

# What does this PR do?

# Why was it initiated? Any relevant Issues?

# PR Checklist

- [ ] Correct base branch selected? Should be `develop` branch.
- [ ] Enabled commit hook or executed `./bin/autoformat-nuitka-source`.
- [ ] All tests still pass. Check the Developer Manual about `Running the Tests`.
      There are GitHub Actions tests that cover the most important
      things however, and you are welcome to rely on those, but they might not
      cover enough.
- [ ] Ideally new features or fixed regressions ought to be covered via new tests.
- [ ] Ideally new or changed features have documentation updates.
